### PR TITLE
content: rewrite homepage copy following style guide

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,12 +7,11 @@ import EmailSignup from '../components/EmailSignup.astro';
   <section class="max-w-5xl mx-auto px-6 py-20">
     <div class="max-w-2xl">
       <h1 class="text-4xl sm:text-5xl font-bold text-charcoal-900 leading-tight">
-        Tools for Claude Code<br />
-        <span class="text-coral-600">power users.</span>
+        Claude Code tools<br />
+        <span class="text-coral-600">I actually use.</span>
       </h1>
       <p class="mt-6 text-lg text-charcoal-700 leading-relaxed">
-        A curated directory of skills, plugins, MCP servers, and prompts to supercharge your
-        AI-assisted development workflow. Quality picks from the community, plus my own builds.
+        I spend way too much time building and testing Claude Code extensions. This is where I publish the ones worth keeping. Skills, plugins, MCP servers. Some I built myself, others I found and verified.
       </p>
       <div class="mt-8 flex flex-wrap gap-4">
         <a href="/plugins" class="inline-flex items-center px-6 py-3 bg-coral-600 text-white font-medium rounded-lg hover:bg-coral-700 transition-colors">
@@ -36,8 +35,8 @@ import EmailSignup from '../components/EmailSignup.astro';
     <div class="max-w-5xl mx-auto px-6 py-16">
       <div class="max-w-md mx-auto">
         <EmailSignup
-          title="Stay in the loop"
-          description="Get notified when new tools drop. No spam, just useful stuff."
+          title="Get notified when I add new tools"
+          description="Usually once or twice a month. I only send updates when there's something genuinely useful."
           source="homepage"
         />
       </div>


### PR DESCRIPTION
Replace generic marketing language with honest, personal voice:
- "Tools for Claude Code power users" → "Claude Code tools I actually use"
- Remove "supercharge" and "curated directory" hype words
- Add conversational authenticity about building and testing extensions
- Update email signup with specific frequency and genuine promise