### PR TITLE
Add ASCII art to logo and plugin components

### DIFF
--- a/docs/plans/in-progress/ascii-art-assets-plan.md
+++ b/docs/plans/in-progress/ascii-art-assets-plan.md
@@ -1,0 +1,266 @@
+# ASCII Art Digital Assets Implementation Plan
+
+## Overview
+
+Transform Channel47's digital assets with ASCII art to create a distinctive CLI-native aesthetic that reinforces the site's identity as a Claude Code plugin marketplace. The goal is to add character while preserving the clean, minimal design system with generous white space.
+
+---
+
+## Part 1: Logo & Wordmark Transformation
+
+### Current State
+- **Header wordmark**: Text-based "Channel47" with weight mixing (bold "Channel" + light "47")
+- **Favicon**: SVG coral-colored abstract shape (`public/favicon.svg`)
+- **Location**: `src/components/Header.astro`
+
+### Proposed Changes
+
+#### 1.1 ASCII Wordmark Component
+Create a new `AsciiLogo.astro` component featuring a compact, elegant ASCII representation:
+
+```
+╔═══════════════════╗
+║  Channel47        ║
+╚═══════════════════╝
+```
+
+Or a more stylized minimal approach:
+```
+┌─ channel ─┐
+│    47     │
+└───────────┘
+```
+
+**Design Philosophy**: Keep it small, monospace, and understated. The ASCII should feel like a subtle nod to the CLI world rather than an overwhelming graphic.
+
+#### 1.2 Implementation Details
+- **File to create**: `src/components/AsciiLogo.astro`
+- **File to modify**: `src/components/Header.astro` - integrate the new component
+- **CSS additions**: `src/styles/components/ascii-logo.css`
+  - Use `font-family: 'JetBrains Mono', monospace`
+  - Small font size (~12-14px) to maintain header elegance
+  - Subtle color: primary text color, no accent colors
+  - Responsive: collapse to simpler version on mobile
+
+#### 1.3 Alternative Concept: Animated ASCII Cursor
+Add a blinking cursor effect after the wordmark to evoke terminal feel:
+```
+Channel47█
+```
+- CSS animation for cursor blink
+- Enhances CLI aesthetic without adding visual complexity
+
+---
+
+## Part 2: Plugin Card ASCII Art Embellishments
+
+### Current State
+- Plugin cards displayed in asymmetric grid (`src/pages/plugins/index.astro`)
+- Cards have: category badge, name, description, meta info
+- Featured cards show installation command
+- Styling in `src/styles/components/plugin-spread.css`
+
+### Proposed Changes
+
+#### 2.1 Category-Specific ASCII Icons
+Add small, tasteful ASCII icons that represent each plugin category. These appear subtly in the top-right corner of cards:
+
+| Category | ASCII Art |
+|----------|-----------|
+| creative | `◈` or `✦` |
+| development | `</>` or `{ }` |
+| writing | `¶` or `≡` |
+| marketing | `◉` or `▣` |
+| data | `⊞` or `⋮⋮⋮` |
+
+**Implementation**:
+- Position: absolute, top-right of card
+- Opacity: 0.15 (very subtle watermark effect)
+- Size: Large (3-4rem) but extremely faint
+- On hover: opacity increases to 0.25
+
+#### 2.2 ASCII Border Accents for Featured Cards
+Featured cards get a subtle ASCII-style corner treatment:
+
+```
+┌──────────────────────────────────────┐
+│  [Featured Plugin Content Here]      │
+└──────────────────────────────────────┘
+```
+
+**Implementation approach**:
+- Use CSS `::before` and `::after` pseudo-elements
+- Only on `.plugin-spread--featured` class
+- Keep border very light: `color: var(--color-gray-200)`
+- White space preserved inside the border frame
+
+#### 2.3 ASCII Art for ascii-art Plugin Card (Meta/Self-Referential)
+The ascii-art plugin itself should showcase its own capability with a small embedded ASCII art preview:
+
+```
+ ╭──────────╮
+ │  ASCII   │
+ │   ART    │
+ ╰──────────╯
+```
+
+This creates a delightful self-referential moment where the plugin demonstrates itself.
+
+---
+
+## Part 3: Files to Create/Modify
+
+### New Files
+
+1. **`src/components/AsciiLogo.astro`**
+   - Compact ASCII wordmark component
+   - Props: `size: 'small' | 'large'`
+   - Responsive behavior built-in
+
+2. **`src/styles/components/ascii-logo.css`**
+   - Monospace font styling
+   - Cursor animation keyframes
+   - Responsive adjustments
+
+3. **`src/components/AsciiIcon.astro`**
+   - Reusable component for category icons
+   - Props: `category: string`
+   - Maps category to appropriate ASCII symbol
+
+### Modified Files
+
+1. **`src/components/Header.astro`**
+   - Import and use `AsciiLogo` component
+   - Replace or augment existing wordmark
+
+2. **`src/pages/plugins/index.astro`**
+   - Import `AsciiIcon` component
+   - Add icon to each plugin card
+   - Add special treatment for ascii-art plugin
+
+3. **`src/styles/components/plugin-spread.css`**
+   - Add styles for ASCII icons (watermark positioning)
+   - Add featured card border treatment
+   - Maintain existing white space principles
+
+4. **`public/favicon.svg`** (optional)
+   - Could be updated to a simple ASCII-inspired geometric shape
+   - Current coral circle could become `[ ]` or similar
+
+---
+
+## Part 4: Design Principles to Maintain
+
+### White Space Preservation
+- All ASCII elements should be subtle additions, not space-fillers
+- Maintain existing padding/margin values
+- Icons and borders should use opacity < 0.3 for watermark effect
+- Never sacrifice readability for decoration
+
+### Clean UI Guidelines
+- Monochrome ASCII (use text colors, not accent colors)
+- Small footprint - ASCII elements should be recognizable but not dominant
+- Consistent sizing across all ASCII elements
+- No animation except subtle cursor blink (optional)
+
+### Responsive Behavior
+- Hide complex ASCII on mobile if needed
+- Simplify to single-character symbols on small screens
+- Maintain touch target sizes for interactive elements
+
+---
+
+## Part 5: Implementation Order
+
+1. **Phase 1: Logo Component**
+   - Create `AsciiLogo.astro`
+   - Create accompanying CSS
+   - Integrate into Header
+
+2. **Phase 2: Category Icons**
+   - Create `AsciiIcon.astro`
+   - Add icon mapping for each category
+   - Integrate into plugin cards
+   - Style with subtle watermark effect
+
+3. **Phase 3: Featured Card Treatment**
+   - Add ASCII border styling for featured cards
+   - Add special ascii-art plugin showcase
+
+4. **Phase 4: Polish**
+   - Test responsive behavior
+   - Verify dark mode compatibility
+   - Fine-tune opacity/sizing values
+
+---
+
+## Part 6: Visual Mockups
+
+### Header (Before)
+```
+Channel47                        Blog  Tools  About
+```
+
+### Header (After)
+```
+┌ Channel47 ┐                    Blog  Tools  About
+```
+or
+```
+Channel47█                       Blog  Tools  About
+```
+
+### Plugin Card (Before)
+```
+┌─────────────────────────────────────────────────┐
+│ CREATIVE                                        │
+│ ascii-art                                       │
+│ Generate ASCII art logos, banners, diagrams... │
+│ by Jackson · v1.1.0                            │
+└─────────────────────────────────────────────────┘
+```
+
+### Plugin Card (After)
+```
+┌─────────────────────────────────────────────────┐
+│ CREATIVE                                    ◈   │ <- faint watermark
+│ ascii-art                                       │
+│                                                 │
+│ Generate ASCII art logos, banners, diagrams... │
+│                                                 │
+│ by Jackson · v1.1.0                            │
+│                                                 │
+│   ╭──────────╮                                 │ <- only for ascii-art
+│   │  ASCII   │                                 │
+│   ╰──────────╯                                 │
+└─────────────────────────────────────────────────┘
+```
+
+### Featured Card (After)
+```
+╭─────────────────────────────────────────────────╮
+│ ┌───────────────────────────────────────────┐   │
+│ │  FEATURED PLUGIN                          │   │
+│ │  plugin-name                              │   │
+│ │  Description...                           │   │
+│ │  claude plugins install plugin-name       │   │
+│ └───────────────────────────────────────────┘   │
+╰─────────────────────────────────────────────────╯
+```
+
+---
+
+## Summary
+
+This plan adds ASCII art character to Channel47 through:
+1. A subtle ASCII-enhanced logo in the header
+2. Faint category icons as watermarks on plugin cards
+3. Special treatment for featured plugins and the ascii-art plugin itself
+
+All additions maintain the existing white space and clean aesthetic by using:
+- Very low opacity for decorative elements
+- Monochrome color palette
+- Small, tasteful ASCII rather than elaborate graphics
+- Proper responsive behavior
+
+The result will be a unique CLI-native aesthetic that differentiates Channel47 while respecting the minimalist design philosophy.

--- a/src/components/AsciiIcon.astro
+++ b/src/components/AsciiIcon.astro
@@ -1,0 +1,64 @@
+---
+// src/components/AsciiIcon.astro
+// Category-specific ASCII art icons as subtle watermarks
+interface Props {
+  category: string;
+  size?: 'small' | 'large';
+}
+
+const { category, size = 'small' } = Astro.props;
+
+// Map categories to ASCII art icons
+const iconMap: Record<string, string> = {
+  creative: '◈',
+  development: '</>',
+  writing: '¶',
+  marketing: '◉',
+  data: '⊞',
+  default: '○'
+};
+
+// Extended ASCII art for large size (used on special cards)
+const largeIconMap: Record<string, string> = {
+  creative: `╭──────╮
+│ ◈◈◈  │
+╰──────╯`,
+  development: `{ code }`,
+  writing: `≡≡≡`,
+  marketing: `[◉]`,
+  data: `┌┬┬┐
+├┼┼┤
+└┴┴┘`,
+  default: '[ ]'
+};
+
+const icon = size === 'large'
+  ? (largeIconMap[category] || largeIconMap.default)
+  : (iconMap[category] || iconMap.default);
+---
+
+<span class={`ascii-icon ascii-icon--${size}`} aria-hidden="true">
+  {icon}
+</span>
+
+<style>
+  .ascii-icon {
+    font-family: 'JetBrains Mono', monospace;
+    color: var(--color-text);
+    opacity: 0.08;
+    user-select: none;
+    pointer-events: none;
+    transition: opacity 200ms ease-out;
+    line-height: 1;
+    white-space: pre;
+  }
+
+  .ascii-icon--small {
+    font-size: 2.5rem;
+  }
+
+  .ascii-icon--large {
+    font-size: 0.875rem;
+    opacity: 0.12;
+  }
+</style>

--- a/src/components/AsciiLogo.astro
+++ b/src/components/AsciiLogo.astro
@@ -1,0 +1,20 @@
+---
+// src/components/AsciiLogo.astro
+// ASCII-styled logo with terminal aesthetic
+interface Props {
+  size?: 'small' | 'large';
+  showCursor?: boolean;
+}
+
+const { size = 'small', showCursor = true } = Astro.props;
+import '../styles/components/ascii-logo.css';
+---
+
+<a href="/" class={`ascii-logo ascii-logo--${size}`}>
+  <span class="ascii-logo__bracket">[</span>
+  <span class="ascii-logo__text">
+    <span class="ascii-logo__bold">Channel</span><span class="ascii-logo__light">47</span>
+  </span>
+  <span class="ascii-logo__bracket">]</span>
+  {showCursor && <span class="ascii-logo__cursor"></span>}
+</a>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,12 +1,11 @@
 ---
 // src/components/Header.astro
 import '../styles/components/header.css';
+import AsciiLogo from './AsciiLogo.astro';
 ---
 <header class="header" id="main-header">
   <nav class="header__nav">
-    <a href="/" class="header__wordmark">
-      <span class="header__wordmark-bold">Channel</span><span class="header__wordmark-light">47</span>
-    </a>
+    <AsciiLogo size="small" showCursor={true} />
     <div class="header__links">
       <a href="/blog" class="header__link">Blog</a>
       <a href="/plugins" class="header__link">Tools</a>

--- a/src/pages/plugins/index.astro
+++ b/src/pages/plugins/index.astro
@@ -2,6 +2,7 @@
 // src/pages/plugins/index.astro
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import AsciiIcon from '../../components/AsciiIcon.astro';
 import mergedPlugins from '../../data/merged-plugins.json';
 import '../../styles/components/plugin-spread.css';
 
@@ -94,12 +95,19 @@ function splitName(name: string): { first: string; second: string } {
         const name = marketplaceData?.name || slug;
         const nameParts = splitName(name);
 
+        const isAsciiArt = slug === 'ascii-art';
+        const category = marketplaceData?.category || 'default';
+
         return (
           <a
             href={`/plugins/${slug}`}
             class={`plugin-spread plugin-spread--${size}`}
             data-category={marketplaceData?.category || 'uncategorized'}
           >
+            <div class="plugin-spread__ascii-icon">
+              <AsciiIcon category={category} size="small" />
+            </div>
+
             <div class="plugin-spread__category" data-category={marketplaceData?.category}>
               {marketplaceData?.category || 'plugin'}
             </div>
@@ -117,6 +125,13 @@ function splitName(name: string): { first: string; second: string } {
               <span>·</span>
               <span>v{marketplaceData?.version || '0.0.0'}</span>
             </div>
+
+            {isAsciiArt && (
+              <div class="plugin-spread__ascii-preview">╭──────────╮
+│  ASCII   │
+│   ART    │
+╰──────────╯</div>
+            )}
 
             {size === 'featured' && marketplaceData?.name && (
               <div class="plugin-spread__code">

--- a/src/styles/components/ascii-logo.css
+++ b/src/styles/components/ascii-logo.css
@@ -1,0 +1,75 @@
+/* ASCII Logo Component */
+.ascii-logo {
+  display: inline-flex;
+  align-items: center;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--color-text);
+  gap: 0;
+  text-decoration: none;
+  transition: color 200ms ease-out;
+}
+
+.ascii-logo:hover {
+  color: var(--color-accent);
+}
+
+.ascii-logo--small {
+  font-size: var(--text-sm);
+}
+
+.ascii-logo--large {
+  font-size: var(--text-lg);
+}
+
+.ascii-logo__bracket {
+  color: var(--color-gray-400);
+  font-weight: 300;
+  transition: color 200ms ease-out;
+}
+
+.ascii-logo:hover .ascii-logo__bracket {
+  color: var(--color-accent);
+}
+
+.ascii-logo__text {
+  padding: 0 0.25em;
+}
+
+.ascii-logo__bold {
+  font-weight: 700;
+}
+
+.ascii-logo__light {
+  font-weight: 300;
+  opacity: 0.8;
+}
+
+.ascii-logo__cursor {
+  display: inline-block;
+  width: 0.5em;
+  height: 1.1em;
+  background-color: var(--color-text);
+  margin-left: 0.15em;
+  animation: cursor-blink 1s step-end infinite;
+  vertical-align: text-bottom;
+}
+
+.ascii-logo:hover .ascii-logo__cursor {
+  background-color: var(--color-accent);
+}
+
+@keyframes cursor-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* Responsive - hide cursor on mobile for cleaner look */
+@media (max-width: 768px) {
+  .ascii-logo__cursor {
+    display: none;
+  }
+
+  .ascii-logo--small {
+    font-size: var(--text-xs);
+  }
+}

--- a/src/styles/components/plugin-spread.css
+++ b/src/styles/components/plugin-spread.css
@@ -64,6 +64,7 @@
 /* Spread Size Variants */
 .plugin-spread {
   display: block;
+  position: relative;
   padding: var(--space-7) 0;
   border-top: 1px solid var(--color-border);
   transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
@@ -94,6 +95,70 @@
 
 .plugin-spread--small {
   grid-column: span 4;
+}
+
+/* ASCII Watermark Icon */
+.plugin-spread__ascii-icon {
+  position: absolute;
+  top: var(--space-6);
+  right: var(--space-4);
+  z-index: 0;
+}
+
+.plugin-spread:hover .plugin-spread__ascii-icon {
+  opacity: 0.15;
+}
+
+/* ASCII Art Preview (for ascii-art plugin) */
+.plugin-spread__ascii-preview {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--text-xs);
+  line-height: 1.2;
+  color: var(--color-text);
+  opacity: 0.6;
+  white-space: pre;
+  margin-top: var(--space-4);
+  padding: var(--space-3);
+  background: var(--color-gray-100);
+  border-radius: 4px;
+  display: inline-block;
+}
+
+.plugin-spread:hover .plugin-spread__ascii-preview {
+  opacity: 0.9;
+}
+
+/* Featured Card ASCII Border */
+.plugin-spread--featured {
+  position: relative;
+}
+
+.plugin-spread--featured::before {
+  content: '┌';
+  position: absolute;
+  top: var(--space-5);
+  left: 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--text-lg);
+  color: var(--color-gray-300);
+  opacity: 0.5;
+}
+
+.plugin-spread--featured::after {
+  content: '┘';
+  position: absolute;
+  bottom: var(--space-5);
+  right: 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--text-lg);
+  color: var(--color-gray-300);
+  opacity: 0.5;
+}
+
+.plugin-spread--featured:hover::before,
+.plugin-spread--featured:hover::after {
+  color: var(--color-accent);
+  opacity: 0.7;
 }
 
 /* Spread Anatomy */


### PR DESCRIPTION
- Create AsciiLogo component with terminal-style brackets and blinking cursor
- Create AsciiIcon component for category-specific watermarks on plugin cards
- Update Header to use new ASCII wordmark ([Channel47]█)
- Add subtle ASCII corner accents to featured plugin cards
- Add self-referential ASCII preview box to ascii-art plugin card
- Maintain clean UI with low-opacity watermarks and generous white space