### PR TITLE
fix: resolve build error and remove unused variables

### DIFF
--- a/scripts/regenerate-images.ts
+++ b/scripts/regenerate-images.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'url';
 import matter from 'gray-matter';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+void __filename; // ESM compatibility
 
 async function regenerateImages(slug: string): Promise<void> {
   // Find the blog post

--- a/scripts/synthesize.ts
+++ b/scripts/synthesize.ts
@@ -1,7 +1,6 @@
 // scripts/synthesize.ts
 import 'dotenv/config';
 import Anthropic from '@anthropic-ai/sdk';
-import { GoogleGenerativeAI } from '@google/generative-ai';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
@@ -13,7 +12,7 @@ const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY,
 });
 
-const gemini = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '');
+// GoogleGenerativeAI SDK initialized when needed in generateImageViaAPI
 
 async function loadPrompt(): Promise<string> {
   const promptPath = path.join(__dirname, 'prompts', 'synthesis.md');

--- a/src/components/TerminalHero.astro
+++ b/src/components/TerminalHero.astro
@@ -58,7 +58,6 @@ const welcomeAscii = `
 
 <script>
   // Terminal Logic
-  const terminalWindow = document.querySelector('.terminal-hero__window');
   const terminalOutput = document.getElementById('terminal-output');
   const bootSequence = document.querySelector('.terminal-boot-sequence');
   const asciiLogo = document.querySelector('.terminal-ascii-logo');
@@ -72,9 +71,6 @@ const welcomeAscii = `
   const LOGO_DELAY = 100;
   const SYSTEM_INFO_DELAY = 600;
   const INPUT_DELAY = 1200;
-
-  // Command Helper
-  const formatLink = (url: string, text: string) => `<a href="${url}" class="terminal-link">${text}</a>`;
 
   // Commands
   const commands: Record<string, (args?: string[]) => string | void> = {

--- a/src/components/home/PluginShowcase.astro
+++ b/src/components/home/PluginShowcase.astro
@@ -2,11 +2,8 @@
 // src/components/home/PluginShowcase.astro
 import ScrollReveal from '../shared/ScrollReveal.astro';
 import { readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+import { join } from 'path';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
 
 // Read ASCII art files
 const asciiDir = join(process.cwd(), 'src/ascii-assets/plugins');
@@ -72,7 +69,7 @@ const plugins: Plugin[] = [
 
   <div class="plugin-showcase__grid">
     {plugins.map((plugin, index) => (
-      <ScrollReveal direction="up" delay={index + 1}>
+      <ScrollReveal direction="up" delay={Math.min(index + 1, 5) as 1 | 2 | 3 | 4 | 5}>
         <a href={plugin.url} class={`terminal-window terminal-window--${plugin.color}`}>
           <div class="terminal-window__bar">
             <div class="terminal-window__buttons">

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -16,7 +16,7 @@ interface Props {
   }>;
 }
 
-const { title, description, date, tags = [], toolsUsed } = Astro.props;
+const { title, description, date, toolsUsed } = Astro.props;
 
 // Format date for display - uppercase month
 const formattedDate = date.toLocaleDateString('en-US', {

--- a/src/pages/plugins/index.astro
+++ b/src/pages/plugins/index.astro
@@ -29,8 +29,6 @@ enrichedPlugins.sort((a, b) => {
 // Get unique categories
 const categories = ['all', ...new Set(mergedPlugins.map(p => p.category).filter(Boolean))];
 
-// Helper to format category for display
-const formatCategory = (cat: string) => cat === 'google-ads' ? 'Google Ads' : cat;
 ---
 
 <BaseLayout
@@ -59,10 +57,6 @@ const formatCategory = (cat: string) => cat === 'google-ads' ? 'Google Ads' : ca
       {enrichedPlugins.map(({ slug, data, marketplaceData, featured }) => {
         const name = marketplaceData?.name || slug;
         const category = marketplaceData?.category || 'uncategorized';
-        // Handle nested author object or string, default to Unknown
-        const authorName = typeof marketplaceData?.author === 'object' 
-          ? marketplaceData.author.name 
-          : (marketplaceData?.author || 'Unknown');
 
         return (
           <a


### PR DESCRIPTION
- Fix ScrollReveal delay type error by casting to expected union type
- Remove unused imports and variables across multiple files:
  - scripts/regenerate-images.ts: __dirname
  - scripts/synthesize.ts: GoogleGenerativeAI import
  - TerminalHero.astro: terminalWindow, formatLink
  - PluginShowcase.astro: fileURLToPath, dirname imports
  - BlogPost.astro: tags destructuring
  - plugins/index.astro: formatCategory, authorName