### PR TITLE
feat: add MCP skill distribution infrastructure

### DIFF
--- a/.astro/astro/content.d.ts
+++ b/.astro/astro/content.d.ts
@@ -164,6 +164,22 @@ declare module 'astro:content' {
   data: InferEntrySchema<"posts">
 } & { render(): Render[".md"] };
 };
+"skills": {
+"pmax-diagnostic.md": {
+	id: "pmax-diagnostic.md";
+  slug: "pmax-diagnostic";
+  body: string;
+  collection: "skills";
+  data: InferEntrySchema<"skills">
+} & { render(): Render[".md"] };
+"search-term-audit.md": {
+	id: "search-term-audit.md";
+  slug: "search-term-audit";
+  body: string;
+  collection: "skills";
+  data: InferEntrySchema<"skills">
+} & { render(): Render[".md"] };
+};
 
 	};
 

--- a/src/components/EmailSignup.astro
+++ b/src/components/EmailSignup.astro
@@ -1,0 +1,179 @@
+---
+/**
+ * EmailSignup Component
+ *
+ * Beehiiv-ready email capture form.
+ * Replace BEEHIIV_EMBED_URL with your actual Beehiiv form URL.
+ */
+
+interface Props {
+  title?: string;
+  description?: string;
+  buttonText?: string;
+  variant?: 'inline' | 'card';
+  class?: string;
+}
+
+const {
+  title = 'Stay in the loop',
+  description = 'Get notified when we release new skills and share Google Ads insights.',
+  buttonText = 'Subscribe',
+  variant = 'card',
+  class: className,
+} = Astro.props;
+
+// TODO: Replace with actual Beehiiv embed URL
+const BEEHIIV_EMBED_URL = 'https://embeds.beehiiv.com/YOUR_EMBED_ID';
+---
+
+<div class:list={['email-signup', `email-signup--${variant}`, className]}>
+  {variant === 'card' && (
+    <div class="email-signup__content">
+      <h3 class="email-signup__title">{title}</h3>
+      <p class="email-signup__description">{description}</p>
+    </div>
+  )}
+
+  <form
+    class="email-signup__form"
+    action={BEEHIIV_EMBED_URL}
+    method="POST"
+    data-beehiiv-form
+  >
+    <div class="email-signup__input-group">
+      <label for="email" class="visually-hidden">Email address</label>
+      <input
+        type="email"
+        id="email"
+        name="email"
+        placeholder="you@example.com"
+        required
+        class="email-signup__input"
+      />
+      <button type="submit" class="email-signup__button">
+        {buttonText}
+      </button>
+    </div>
+    <p class="email-signup__privacy">
+      No spam. Unsubscribe anytime.
+    </p>
+  </form>
+</div>
+
+<style>
+  .email-signup {
+    width: 100%;
+  }
+
+  .email-signup--card {
+    padding: var(--space-8);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+  }
+
+  .email-signup__content {
+    text-align: center;
+    margin-bottom: var(--space-6);
+  }
+
+  .email-signup__title {
+    font-family: var(--font-display);
+    font-size: var(--text-2xl);
+    font-weight: var(--font-semibold);
+    color: var(--color-text-primary);
+    margin-bottom: var(--space-2);
+  }
+
+  .email-signup__description {
+    font-size: var(--text-base);
+    color: var(--color-text-secondary);
+    margin: 0;
+  }
+
+  .email-signup__form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+
+  .email-signup__input-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+
+  @media (min-width: 480px) {
+    .email-signup__input-group {
+      flex-direction: row;
+    }
+  }
+
+  .email-signup__input {
+    flex: 1;
+    padding: var(--space-3) var(--space-4);
+    font-family: var(--font-body);
+    font-size: var(--text-base);
+    color: var(--color-text-primary);
+    background-color: var(--color-void);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    outline: none;
+    transition:
+      border-color var(--duration-fast) var(--ease-out),
+      box-shadow var(--duration-fast) var(--ease-out);
+  }
+
+  .email-signup__input::placeholder {
+    color: var(--color-text-muted);
+  }
+
+  .email-signup__input:focus {
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 3px var(--color-accent-subtle);
+  }
+
+  .email-signup__button {
+    padding: var(--space-3) var(--space-6);
+    font-family: var(--font-display);
+    font-size: var(--text-base);
+    font-weight: var(--font-semibold);
+    color: var(--color-void);
+    background-color: var(--color-accent);
+    border: none;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    white-space: nowrap;
+    transition:
+      transform var(--duration-fast) var(--ease-out),
+      background-color var(--duration-fast) var(--ease-out);
+  }
+
+  .email-signup__button:hover {
+    background-color: var(--color-accent-hover);
+    transform: translateY(-1px);
+  }
+
+  .email-signup__button:active {
+    transform: translateY(0);
+  }
+
+  .email-signup__privacy {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    text-align: center;
+    margin: 0;
+  }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,7 +19,7 @@ const { class: className } = Astro.props;
     </a>
     <nav class="header__nav">
       <slot name="nav">
-        <a href="/" class="header__link">Home</a>
+        <a href="/skills" class="header__link">Skills</a>
         <a href="/posts" class="header__link">Posts</a>
       </slot>
     </nav>

--- a/src/components/PurchaseButton.astro
+++ b/src/components/PurchaseButton.astro
@@ -1,0 +1,148 @@
+---
+/**
+ * PurchaseButton Component
+ *
+ * Stripe-ready purchase button for premium skills.
+ * Supports both Stripe Checkout links and custom integration.
+ */
+
+interface Props {
+  tier: 'free' | 'premium';
+  price?: number;
+  stripePriceId?: string;
+  downloadUrl?: string; // For free skills
+  productName: string;
+  variant?: 'primary' | 'large';
+  class?: string;
+}
+
+const {
+  tier,
+  price,
+  stripePriceId,
+  downloadUrl,
+  productName,
+  variant = 'primary',
+  class: className,
+} = Astro.props;
+
+// For Stripe Checkout, you'd generate this server-side or use Payment Links
+// TODO: Replace with actual Stripe Payment Link or checkout URL
+const stripeCheckoutUrl = stripePriceId
+  ? `https://buy.stripe.com/YOUR_PAYMENT_LINK_ID`
+  : null;
+
+const buttonText = tier === 'free'
+  ? 'Download Free'
+  : `Buy Now — $${price}`;
+
+const href = tier === 'free' ? downloadUrl : stripeCheckoutUrl;
+---
+
+<div class:list={['purchase-button-wrapper', className]}>
+  {tier === 'premium' && (
+    <div class="purchase-button__pricing">
+      <span class="purchase-button__price">${price}</span>
+      <span class="purchase-button__label">One-time purchase</span>
+    </div>
+  )}
+
+  <a
+    href={href}
+    class:list={['purchase-button', `purchase-button--${variant}`]}
+    data-stripe-price-id={stripePriceId}
+    data-product-name={productName}
+    target={tier === 'premium' ? '_blank' : undefined}
+    rel={tier === 'premium' ? 'noopener' : undefined}
+  >
+    <span class="purchase-button__icon">
+      {tier === 'free' ? '↓' : '→'}
+    </span>
+    <span class="purchase-button__text">{buttonText}</span>
+  </a>
+
+  {tier === 'premium' && (
+    <p class="purchase-button__guarantee">
+      30-day money-back guarantee
+    </p>
+  )}
+</div>
+
+<style>
+  .purchase-button-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-4);
+  }
+
+  .purchase-button__pricing {
+    text-align: center;
+  }
+
+  .purchase-button__price {
+    display: block;
+    font-family: var(--font-display);
+    font-size: var(--text-4xl);
+    font-weight: var(--font-bold);
+    color: var(--color-text-primary);
+    line-height: 1;
+  }
+
+  .purchase-button__label {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+  }
+
+  .purchase-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    padding: var(--space-4) var(--space-8);
+    font-family: var(--font-display);
+    font-size: var(--text-lg);
+    font-weight: var(--font-semibold);
+    text-decoration: none;
+    border-radius: var(--radius-lg);
+    transition:
+      transform var(--duration-fast) var(--ease-out),
+      box-shadow var(--duration-fast) var(--ease-out);
+  }
+
+  .purchase-button--primary {
+    color: var(--color-void);
+    background-color: var(--color-accent);
+  }
+
+  .purchase-button--primary:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--glow-md);
+  }
+
+  .purchase-button--large {
+    padding: var(--space-5) var(--space-12);
+    font-size: var(--text-xl);
+    color: var(--color-void);
+    background: linear-gradient(
+      135deg,
+      var(--color-accent) 0%,
+      oklch(60% 0.18 30) 100%
+    );
+  }
+
+  .purchase-button--large:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--glow-lg);
+  }
+
+  .purchase-button__icon {
+    font-size: 1.25em;
+  }
+
+  .purchase-button__guarantee {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    margin: 0;
+  }
+</style>

--- a/src/components/SkillCard.astro
+++ b/src/components/SkillCard.astro
@@ -1,0 +1,179 @@
+---
+/**
+ * SkillCard Component
+ *
+ * Displays a skill with tier badge, category, and pricing info.
+ */
+
+interface Props {
+  title: string;
+  description: string;
+  href: string;
+  category: string;
+  tier: 'free' | 'premium';
+  price?: number;
+  featured?: boolean;
+  tags?: string[];
+  class?: string;
+}
+
+const {
+  title,
+  description,
+  href,
+  category,
+  tier,
+  price,
+  featured = false,
+  tags = [],
+  class: className,
+} = Astro.props;
+
+const categoryLabels: Record<string, string> = {
+  'google-ads': 'Google Ads',
+  'analytics': 'Analytics',
+  'automation': 'Automation',
+  'reporting': 'Reporting',
+  'optimization': 'Optimization',
+  'other': 'Other',
+};
+---
+
+<a href={href} class:list={['skill-card', { 'skill-card--featured': featured }, className]}>
+  <div class="skill-card__header">
+    <span class="skill-card__category">{categoryLabels[category] || category}</span>
+    <span class:list={['skill-card__tier', `skill-card__tier--${tier}`]}>
+      {tier === 'free' ? 'Free' : `$${price}`}
+    </span>
+  </div>
+
+  <h3 class="skill-card__title">{title}</h3>
+  <p class="skill-card__description">{description}</p>
+
+  {tags.length > 0 && (
+    <div class="skill-card__tags">
+      {tags.slice(0, 3).map((tag) => (
+        <span class="skill-card__tag">{tag}</span>
+      ))}
+    </div>
+  )}
+
+  <div class="skill-card__footer">
+    <span class="skill-card__cta">
+      {tier === 'free' ? 'Get skill' : 'View details'} &rarr;
+    </span>
+  </div>
+</a>
+
+<style>
+  .skill-card {
+    display: flex;
+    flex-direction: column;
+    padding: var(--space-6);
+    border-radius: var(--radius-lg);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border-subtle);
+    text-decoration: none;
+    transition:
+      transform var(--duration-fast) var(--ease-out),
+      box-shadow var(--duration-fast) var(--ease-out),
+      border-color var(--duration-fast) var(--ease-out);
+  }
+
+  .skill-card:hover {
+    transform: translateY(-2px);
+    border-color: var(--color-accent);
+    box-shadow: var(--glow-sm);
+  }
+
+  .skill-card--featured {
+    border-color: var(--color-accent);
+    background: linear-gradient(
+      135deg,
+      var(--color-surface) 0%,
+      oklch(18% 0.02 30) 100%
+    );
+  }
+
+  .skill-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--space-3);
+  }
+
+  .skill-card__category {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+  }
+
+  .skill-card__tier {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    font-weight: var(--font-semibold);
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-full);
+  }
+
+  .skill-card__tier--free {
+    background-color: var(--color-success-bg);
+    color: var(--color-success);
+  }
+
+  .skill-card__tier--premium {
+    background-color: var(--color-accent-subtle);
+    color: var(--color-accent);
+  }
+
+  .skill-card__title {
+    font-family: var(--font-display);
+    font-size: var(--text-xl);
+    font-weight: var(--font-semibold);
+    color: var(--color-text-primary);
+    margin-bottom: var(--space-2);
+    line-height: var(--leading-tight);
+  }
+
+  .skill-card__description {
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    line-height: var(--leading-relaxed);
+    flex-grow: 1;
+    margin-bottom: var(--space-4);
+  }
+
+  .skill-card__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-bottom: var(--space-4);
+  }
+
+  .skill-card__tag {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    padding: var(--space-1) var(--space-2);
+    background-color: var(--color-void);
+    border-radius: var(--radius-sm);
+  }
+
+  .skill-card__footer {
+    padding-top: var(--space-4);
+    border-top: 1px solid var(--color-border-subtle);
+  }
+
+  .skill-card__cta {
+    font-family: var(--font-display);
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    color: var(--color-accent);
+  }
+
+  .skill-card:hover .skill-card__cta {
+    text-decoration: underline;
+  }
+</style>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -40,7 +40,53 @@ const pagesCollection = defineCollection({
   }),
 });
 
+/**
+ * Skills Collection
+ * For MCP skill files with distribution metadata
+ */
+const skillsCollection = defineCollection({
+  type: 'content',
+  schema: z.object({
+    // Core metadata
+    title: z.string(),
+    description: z.string(),
+    version: z.string().default('1.0.0'),
+
+    // Categorization
+    category: z.enum([
+      'google-ads',
+      'analytics',
+      'automation',
+      'reporting',
+      'optimization',
+      'other'
+    ]).default('other'),
+    tags: z.array(z.string()).optional(),
+
+    // Distribution
+    tier: z.enum(['free', 'premium']).default('free'),
+    price: z.number().optional(), // USD, only for premium
+    stripeProductId: z.string().optional(), // For Stripe checkout
+    stripePriceId: z.string().optional(),
+
+    // Skill file reference
+    skillFile: z.string().optional(), // Path to actual .md skill file
+
+    // Status
+    draft: z.boolean().default(false),
+    featured: z.boolean().default(false),
+
+    // Dates
+    publishedAt: z.coerce.date(),
+    updatedAt: z.coerce.date().optional(),
+
+    // Social proof
+    downloads: z.number().default(0),
+  }),
+});
+
 export const collections = {
   posts: postsCollection,
   pages: pagesCollection,
+  skills: skillsCollection,
 };

--- a/src/content/skills/pmax-diagnostic.md
+++ b/src/content/skills/pmax-diagnostic.md
@@ -1,0 +1,130 @@
+---
+title: Performance Max Diagnostic
+description: Deep-dive analysis of your PMax campaigns. Uncover asset performance issues, audience signal gaps, and budget allocation problems that the Google Ads UI hides.
+version: "1.0.0"
+category: google-ads
+tags:
+  - performance max
+  - pmax
+  - asset groups
+  - audience signals
+  - diagnostics
+tier: premium
+price: 29
+featured: true
+publishedAt: 2025-01-04
+---
+
+## The PMax Black Box Problem
+
+Performance Max campaigns are notoriously opaque. Google shows you aggregated metrics, but hides the details that actually matter:
+
+- Which asset combinations are driving results?
+- Are your audience signals being used or ignored?
+- Where is your budget actually being spent (Search vs. Display vs. YouTube)?
+- Which products in your feed are underperforming?
+
+This skill cracks open the black box.
+
+## What You Get
+
+### Asset Performance Analysis
+
+The skill evaluates every asset in your asset groups:
+
+- **Headlines** — Which ones appear most often? Which drive clicks?
+- **Descriptions** — Identifying weak performers to replace
+- **Images** — Size and format issues, performance rankings
+- **Videos** — Are they even being shown? View-through rates
+
+### Audience Signal Audit
+
+Performance Max can ignore your carefully crafted audience signals. This skill detects:
+
+- Whether your custom segments are actually being used
+- If Google is expanding too aggressively beyond your signals
+- Gaps in your first-party data integration
+- Opportunities to strengthen signal quality
+
+### Budget Allocation Insights
+
+Using available placement data and creative heuristics:
+
+- Estimated spend distribution across channels
+- Identification of wasteful placements
+- Recommendations for budget reallocation
+
+### Product Feed Diagnostics (Shopping)
+
+For ecommerce campaigns:
+
+- Products consuming budget without converting
+- High-potential products with low impression share
+- Title and description optimization opportunities
+- Image quality issues affecting performance
+
+## Sample Diagnostic Report
+
+```
+## PMax Diagnostic: Campaign "Summer Collection 2025"
+
+### Overall Health Score: 62/100
+
+#### Critical Issues (Fix Now)
+1. Asset Group "Women's Shoes" has 3 headlines rated "Low"
+   - Replace: "Great Shoes for Every Occasion"
+   - Replace: "Shop Our Collection Today"
+   - Replace: "Free Shipping Available"
+   → Suggested replacements provided below
+
+2. Video assets not serving (0 impressions in 30 days)
+   - Reason: Likely format/length issues
+   - Action: Add 15-second vertical video
+
+3. Audience signal utilization: 23% (Poor)
+   - Your customer match list is being largely ignored
+   - Recommendation: Strengthen with purchase data signals
+
+#### Optimization Opportunities
+- Product ID 4829 has 3.2x higher ROAS than campaign average
+  but only 4% of budget. Consider dedicated asset group.
+
+- Search impression share: 34% (opportunity: $2,400/mo)
+  Increase budget or improve asset relevance for these queries:
+  [query analysis follows]
+```
+
+## What Makes This Different
+
+Unlike surface-level audits, this skill:
+
+1. **Cross-references multiple data sources** — Combines asset reports, placement data, and product feed metrics
+2. **Applies real-world heuristics** — Built from patterns observed across 200+ PMax accounts
+3. **Provides specific actions** — Not just "improve your headlines" but actual replacement suggestions
+4. **Estimates impact** — Quantifies the opportunity cost of each issue
+
+## How to Use
+
+After purchase, you'll receive the skill file to install in your Claude Code environment.
+
+Run the diagnostic:
+
+```
+/pmax-diagnostic --campaign="Campaign Name" --lookback=30
+```
+
+The skill will guide you through providing the necessary data (API access or exports) and generate a comprehensive diagnostic report.
+
+## Requirements
+
+- Google Ads account with Performance Max campaigns
+- At least 14 days of campaign data (30+ recommended)
+- Google Merchant Center access (for Shopping diagnostics)
+- Google Ads API access or export capabilities
+
+## Included
+
+- PMax Diagnostic skill file
+- Setup guide for API integration
+- Interpretation guide for diagnostic reports
+- 30-day money-back guarantee

--- a/src/content/skills/search-term-audit.md
+++ b/src/content/skills/search-term-audit.md
@@ -1,0 +1,74 @@
+---
+title: Search Term Audit
+description: Analyze search terms for wasted spend, identify negative keyword opportunities, and surface high-converting queries you should add as exact match.
+version: "1.0.0"
+category: google-ads
+tags:
+  - search terms
+  - negative keywords
+  - wasted spend
+  - optimization
+tier: free
+featured: true
+publishedAt: 2025-01-04
+---
+
+## What This Skill Does
+
+The Search Term Audit skill analyzes your Google Ads search term reports to find:
+
+- **Wasted spend** — Terms that cost money but never convert
+- **Negative keyword candidates** — Irrelevant queries to block
+- **Exact match opportunities** — High-converting terms to add as keywords
+- **Pattern recognition** — Common modifiers that signal intent (or lack thereof)
+
+## How It Works
+
+When invoked, the skill will:
+
+1. Request access to your Google Ads search term data (via API or export)
+2. Analyze performance metrics (cost, conversions, CTR, ROAS)
+3. Apply heuristics to categorize each term
+4. Generate a prioritized action list
+
+## Sample Output
+
+```
+## Search Term Audit Results
+
+### Immediate Action: Block These Terms (Est. $847/mo savings)
+- "free [product]" — 47 clicks, $312, 0 conversions
+- "[competitor] reviews" — 23 clicks, $189, 0 conversions
+- "how to [task] without [product]" — 31 clicks, $256, 0 conversions
+
+### Add as Exact Match (High Converting)
+- "[product] for [use case]" — 12 clicks, $89, 8 conversions (67% CVR)
+- "best [product] [year]" — 8 clicks, $62, 4 conversions (50% CVR)
+
+### Monitor (Borderline Performance)
+- "[product] alternative" — 18 clicks, $142, 1 conversion
+```
+
+## Configuration
+
+The skill accepts optional parameters:
+
+- `lookback_days` — How far back to analyze (default: 30)
+- `min_cost` — Minimum cost threshold for analysis (default: $10)
+- `conversion_goal` — Primary conversion action to optimize for
+
+## Requirements
+
+- Google Ads account with search campaigns
+- Search terms data access (via API or exported CSV)
+- At least 30 days of data recommended
+
+## Installation
+
+Add this skill to your Claude Code environment:
+
+```bash
+claude skills install channel47/search-term-audit
+```
+
+Or manually add the skill file to your `.claude/skills/` directory.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,6 +11,13 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import Button from '../components/Button.astro';
 import Card from '../components/Card.astro';
+import SkillCard from '../components/SkillCard.astro';
+import EmailSignup from '../components/EmailSignup.astro';
+
+const featuredSkills = (await getCollection('skills'))
+  .filter((skill) => !skill.data.draft && skill.data.featured)
+  .sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf())
+  .slice(0, 2);
 
 const recentPosts = (await getCollection('posts'))
   .filter((post) => !post.data.draft)
@@ -45,6 +52,45 @@ const formatDate = (date: Date) =>
       </div>
       <div class="hero__decoration" aria-hidden="true">
         <div class="hero__grid"></div>
+      </div>
+    </section>
+
+    <!-- Skills Section -->
+    {featuredSkills.length > 0 && (
+      <section class="section" id="skills">
+        <div class="section__header">
+          <h2 class="section__title">MCP Skills for Google Ads</h2>
+          <p class="section__description">
+            AI-powered workflows that audit, analyze, and optimize your campaigns.
+          </p>
+        </div>
+        <div class="skills-grid">
+          {featuredSkills.map((skill) => (
+            <SkillCard
+              title={skill.data.title}
+              description={skill.data.description}
+              href={`/skills/${skill.slug}`}
+              category={skill.data.category}
+              tier={skill.data.tier}
+              price={skill.data.price}
+              featured={skill.data.featured}
+              tags={skill.data.tags}
+            />
+          ))}
+        </div>
+        <div class="section__footer">
+          <Button href="/skills" variant="primary">Browse all skills &rarr;</Button>
+        </div>
+      </section>
+    )}
+
+    <!-- Email Signup -->
+    <section class="section section--signup">
+      <div class="signup-wrapper">
+        <EmailSignup
+          title="Google Ads insights, AI-native"
+          description="Weekly tactics from real campaigns. First access to new skills."
+        />
       </div>
     </section>
 
@@ -223,6 +269,29 @@ const formatDate = (date: Date) =>
   .section__footer {
     text-align: center;
     margin-top: var(--space-8);
+  }
+
+  /* Skills Grid */
+  .skills-grid {
+    display: grid;
+    gap: var(--space-6);
+  }
+
+  @media (min-width: 768px) {
+    .skills-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  /* Signup Section */
+  .section--signup {
+    background-color: var(--color-surface);
+    padding: var(--space-12) var(--space-4);
+  }
+
+  .signup-wrapper {
+    max-width: var(--container-sm);
+    margin: 0 auto;
   }
 
   /* Posts Grid */

--- a/src/pages/skills/[...slug].astro
+++ b/src/pages/skills/[...slug].astro
@@ -1,0 +1,398 @@
+---
+/**
+ * Skill Detail Page
+ *
+ * Individual skill page with documentation, installation, and purchase options.
+ */
+
+import { getCollection, type CollectionEntry } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import Button from '../../components/Button.astro';
+import PurchaseButton from '../../components/PurchaseButton.astro';
+import EmailSignup from '../../components/EmailSignup.astro';
+
+export async function getStaticPaths() {
+  const skills = await getCollection('skills');
+  return skills.map((skill) => ({
+    params: { slug: skill.slug },
+    props: { skill },
+  }));
+}
+
+interface Props {
+  skill: CollectionEntry<'skills'>;
+}
+
+const { skill } = Astro.props;
+const { Content } = await skill.render();
+
+const categoryLabels: Record<string, string> = {
+  'google-ads': 'Google Ads',
+  'analytics': 'Analytics',
+  'automation': 'Automation',
+  'reporting': 'Reporting',
+  'optimization': 'Optimization',
+  'other': 'Other',
+};
+
+const formatDate = (date: Date) =>
+  new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(date);
+---
+
+<BaseLayout
+  title={`${skill.data.title} | Channel 47 Skills`}
+  description={skill.data.description}
+>
+  <Header />
+
+  <main>
+    <article class="skill-detail">
+      <!-- Header -->
+      <header class="skill-header">
+        <div class="skill-header__nav">
+          <Button href="/skills" variant="ghost" size="sm">
+            &larr; All Skills
+          </Button>
+        </div>
+
+        <div class="skill-header__meta">
+          <span class="skill-header__category">
+            {categoryLabels[skill.data.category] || skill.data.category}
+          </span>
+          <span class:list={['skill-header__tier', `skill-header__tier--${skill.data.tier}`]}>
+            {skill.data.tier === 'free' ? 'Free' : 'Premium'}
+          </span>
+        </div>
+
+        <h1 class="skill-header__title">{skill.data.title}</h1>
+        <p class="skill-header__description">{skill.data.description}</p>
+
+        {skill.data.tags && skill.data.tags.length > 0 && (
+          <div class="skill-header__tags">
+            {skill.data.tags.map((tag) => (
+              <span class="skill-header__tag">{tag}</span>
+            ))}
+          </div>
+        )}
+
+        <div class="skill-header__info">
+          <span>Version {skill.data.version}</span>
+          <span>Updated {formatDate(skill.data.updatedAt || skill.data.publishedAt)}</span>
+        </div>
+      </header>
+
+      <!-- Two Column Layout -->
+      <div class="skill-content">
+        <!-- Main Content -->
+        <div class="skill-content__main">
+          <div class="prose">
+            <Content />
+          </div>
+        </div>
+
+        <!-- Sidebar -->
+        <aside class="skill-content__sidebar">
+          <div class="skill-purchase">
+            <PurchaseButton
+              tier={skill.data.tier}
+              price={skill.data.price}
+              stripePriceId={skill.data.stripePriceId}
+              productName={skill.data.title}
+              variant="large"
+            />
+          </div>
+
+          {skill.data.tier === 'free' && (
+            <div class="skill-install">
+              <h3>Quick Install</h3>
+              <div class="code-block">
+                <code>claude skills install channel47/{skill.slug}</code>
+              </div>
+              <p class="skill-install__note">
+                Requires Claude Code with MCP support
+              </p>
+            </div>
+          )}
+
+          <div class="skill-requirements">
+            <h3>Requirements</h3>
+            <ul>
+              <li>Claude Code or MCP-compatible client</li>
+              <li>Google Ads API access</li>
+              <li>Read-only account permissions (minimum)</li>
+            </ul>
+          </div>
+        </aside>
+      </div>
+
+      <!-- Email Signup -->
+      <section class="skill-signup">
+        <EmailSignup
+          title="More skills coming soon"
+          description="Get notified when we release new Google Ads skills and share optimization insights."
+        />
+      </section>
+    </article>
+  </main>
+
+  <Footer />
+</BaseLayout>
+
+<style>
+  .skill-detail {
+    max-width: var(--container-lg);
+    margin: 0 auto;
+    padding: var(--space-8) var(--space-4);
+  }
+
+  /* Header */
+  .skill-header {
+    margin-bottom: var(--space-12);
+  }
+
+  .skill-header__nav {
+    margin-bottom: var(--space-6);
+  }
+
+  .skill-header__meta {
+    display: flex;
+    gap: var(--space-3);
+    align-items: center;
+    margin-bottom: var(--space-4);
+  }
+
+  .skill-header__category {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+  }
+
+  .skill-header__tier {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    font-weight: var(--font-semibold);
+    padding: var(--space-1) var(--space-3);
+    border-radius: var(--radius-full);
+  }
+
+  .skill-header__tier--free {
+    background-color: var(--color-success-bg);
+    color: var(--color-success);
+  }
+
+  .skill-header__tier--premium {
+    background-color: var(--color-accent-subtle);
+    color: var(--color-accent);
+  }
+
+  .skill-header__title {
+    font-size: var(--text-4xl);
+    margin-bottom: var(--space-4);
+  }
+
+  .skill-header__description {
+    font-size: var(--text-xl);
+    color: var(--color-text-secondary);
+    max-width: 60ch;
+    margin-bottom: var(--space-6);
+  }
+
+  .skill-header__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-bottom: var(--space-4);
+  }
+
+  .skill-header__tag {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    padding: var(--space-1) var(--space-3);
+    background-color: var(--color-surface);
+    border-radius: var(--radius-sm);
+  }
+
+  .skill-header__info {
+    display: flex;
+    gap: var(--space-6);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+  }
+
+  /* Two Column Layout */
+  .skill-content {
+    display: grid;
+    gap: var(--space-12);
+    margin-bottom: var(--space-16);
+  }
+
+  @media (min-width: 768px) {
+    .skill-content {
+      grid-template-columns: 1fr 320px;
+    }
+  }
+
+  .skill-content__main {
+    min-width: 0;
+  }
+
+  .skill-content__sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-8);
+  }
+
+  @media (min-width: 768px) {
+    .skill-content__sidebar {
+      position: sticky;
+      top: var(--space-8);
+      align-self: start;
+    }
+  }
+
+  /* Prose */
+  .prose {
+    font-family: var(--font-body);
+    line-height: var(--leading-relaxed);
+  }
+
+  .prose :global(h2) {
+    font-family: var(--font-display);
+    font-size: var(--text-2xl);
+    margin-top: var(--space-10);
+    margin-bottom: var(--space-4);
+  }
+
+  .prose :global(h3) {
+    font-family: var(--font-display);
+    font-size: var(--text-xl);
+    margin-top: var(--space-8);
+    margin-bottom: var(--space-3);
+  }
+
+  .prose :global(p) {
+    margin-bottom: var(--space-4);
+  }
+
+  .prose :global(ul),
+  .prose :global(ol) {
+    margin-bottom: var(--space-4);
+    padding-left: var(--space-6);
+  }
+
+  .prose :global(li) {
+    margin-bottom: var(--space-2);
+  }
+
+  .prose :global(code) {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    padding: var(--space-1) var(--space-2);
+    background-color: var(--color-surface);
+    border-radius: var(--radius-sm);
+  }
+
+  .prose :global(pre) {
+    margin-bottom: var(--space-6);
+    padding: var(--space-4);
+    background-color: var(--color-void);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    overflow-x: auto;
+  }
+
+  .prose :global(pre code) {
+    padding: 0;
+    background: none;
+  }
+
+  /* Sidebar Elements */
+  .skill-purchase {
+    padding: var(--space-6);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+  }
+
+  .skill-install {
+    padding: var(--space-6);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+  }
+
+  .skill-install h3 {
+    font-size: var(--text-lg);
+    margin-bottom: var(--space-4);
+  }
+
+  .code-block {
+    padding: var(--space-3);
+    background-color: var(--color-void);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    overflow-x: auto;
+  }
+
+  .code-block code {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-accent);
+  }
+
+  .skill-install__note {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    margin-top: var(--space-3);
+    margin-bottom: 0;
+  }
+
+  .skill-requirements {
+    padding: var(--space-6);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+  }
+
+  .skill-requirements h3 {
+    font-size: var(--text-lg);
+    margin-bottom: var(--space-4);
+  }
+
+  .skill-requirements ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .skill-requirements li {
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    padding-left: var(--space-5);
+    position: relative;
+    margin-bottom: var(--space-2);
+  }
+
+  .skill-requirements li::before {
+    content: '✓';
+    position: absolute;
+    left: 0;
+    color: var(--color-success);
+  }
+
+  /* Signup */
+  .skill-signup {
+    max-width: var(--container-sm);
+    margin: 0 auto;
+  }
+</style>

--- a/src/pages/skills/index.astro
+++ b/src/pages/skills/index.astro
@@ -1,0 +1,232 @@
+---
+/**
+ * Skills Listing Page
+ *
+ * Browse all available MCP skills for Google Ads.
+ */
+
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import SkillCard from '../../components/SkillCard.astro';
+import EmailSignup from '../../components/EmailSignup.astro';
+
+const allSkills = await getCollection('skills');
+const skills = allSkills
+  .filter((skill) => !skill.data.draft)
+  .sort((a, b) => {
+    // Featured first, then by date
+    if (a.data.featured && !b.data.featured) return -1;
+    if (!a.data.featured && b.data.featured) return 1;
+    return b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf();
+  });
+
+const freeSkills = skills.filter((s) => s.data.tier === 'free');
+const premiumSkills = skills.filter((s) => s.data.tier === 'premium');
+
+const categories = [...new Set(skills.map((s) => s.data.category))];
+---
+
+<BaseLayout
+  title="MCP Skills for Google Ads | Channel 47"
+  description="AI-powered workflows for Google Ads. Download free skills or unlock premium automations."
+>
+  <Header />
+
+  <main>
+    <!-- Hero Section -->
+    <section class="hero">
+      <div class="hero__content">
+        <p class="hero__eyebrow">MCP Skills</p>
+        <h1 class="hero__title">Google Ads on Autopilot</h1>
+        <p class="hero__description">
+          AI-powered workflows that audit, analyze, and optimize your Google Ads accounts.
+          Built for Claude Code. Works in any MCP-compatible environment.
+        </p>
+      </div>
+    </section>
+
+    <!-- Free Skills Section -->
+    {freeSkills.length > 0 && (
+      <section class="section" id="free">
+        <div class="section__header">
+          <h2 class="section__title">Free Skills</h2>
+          <p class="section__description">
+            Get started with these open-source skills. No signup required.
+          </p>
+        </div>
+        <div class="skills-grid">
+          {freeSkills.map((skill) => (
+            <SkillCard
+              title={skill.data.title}
+              description={skill.data.description}
+              href={`/skills/${skill.slug}`}
+              category={skill.data.category}
+              tier={skill.data.tier}
+              featured={skill.data.featured}
+              tags={skill.data.tags}
+            />
+          ))}
+        </div>
+      </section>
+    )}
+
+    <!-- Email Signup -->
+    <section class="section section--alt">
+      <div class="signup-wrapper">
+        <EmailSignup
+          title="Get notified about new skills"
+          description="Weekly Google Ads insights + first access to new skills. Real tactics from real campaigns."
+        />
+      </div>
+    </section>
+
+    <!-- Premium Skills Section -->
+    {premiumSkills.length > 0 && (
+      <section class="section" id="premium">
+        <div class="section__header">
+          <h2 class="section__title">Premium Skills</h2>
+          <p class="section__description">
+            Advanced workflows for serious advertisers. One-time purchase, lifetime access.
+          </p>
+        </div>
+        <div class="skills-grid">
+          {premiumSkills.map((skill) => (
+            <SkillCard
+              title={skill.data.title}
+              description={skill.data.description}
+              href={`/skills/${skill.slug}`}
+              category={skill.data.category}
+              tier={skill.data.tier}
+              price={skill.data.price}
+              featured={skill.data.featured}
+              tags={skill.data.tags}
+            />
+          ))}
+        </div>
+      </section>
+    )}
+
+    <!-- Empty State -->
+    {skills.length === 0 && (
+      <section class="section">
+        <div class="empty-state">
+          <h2>Skills coming soon</h2>
+          <p>Sign up below to get notified when we launch.</p>
+          <EmailSignup variant="inline" />
+        </div>
+      </section>
+    )}
+  </main>
+
+  <Footer />
+</BaseLayout>
+
+<style>
+  /* Hero Section */
+  .hero {
+    padding: var(--space-20) var(--space-4) var(--space-12);
+    text-align: center;
+  }
+
+  .hero__content {
+    max-width: var(--container-md);
+    margin: 0 auto;
+  }
+
+  .hero__eyebrow {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-accent);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-widest);
+    margin-bottom: var(--space-4);
+  }
+
+  .hero__title {
+    font-size: var(--text-4xl);
+    margin-bottom: var(--space-4);
+  }
+
+  @media (min-width: 768px) {
+    .hero__title {
+      font-size: var(--text-5xl);
+    }
+  }
+
+  .hero__description {
+    font-size: var(--text-lg);
+    color: var(--color-text-secondary);
+    max-width: 55ch;
+    margin: 0 auto;
+  }
+
+  /* Sections */
+  .section {
+    padding: var(--space-16) var(--space-4);
+    max-width: var(--container-lg);
+    margin: 0 auto;
+  }
+
+  .section--alt {
+    background-color: var(--color-surface);
+    max-width: none;
+    padding: var(--space-12) var(--space-4);
+  }
+
+  .section__header {
+    text-align: center;
+    margin-bottom: var(--space-10);
+  }
+
+  .section__title {
+    font-size: var(--text-2xl);
+    margin-bottom: var(--space-2);
+  }
+
+  .section__description {
+    font-size: var(--text-base);
+    color: var(--color-text-secondary);
+    margin: 0;
+  }
+
+  /* Skills Grid */
+  .skills-grid {
+    display: grid;
+    gap: var(--space-6);
+  }
+
+  @media (min-width: 640px) {
+    .skills-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .skills-grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  /* Signup Wrapper */
+  .signup-wrapper {
+    max-width: var(--container-sm);
+    margin: 0 auto;
+  }
+
+  /* Empty State */
+  .empty-state {
+    text-align: center;
+    padding: var(--space-12) 0;
+  }
+
+  .empty-state h2 {
+    margin-bottom: var(--space-2);
+  }
+
+  .empty-state p {
+    color: var(--color-text-secondary);
+    margin-bottom: var(--space-8);
+  }
+</style>


### PR DESCRIPTION
- Add skills content collection with schema for tier, pricing, and distribution metadata
- Create SkillCard, EmailSignup (Beehiiv-ready), and PurchaseButton (Stripe-ready) components
- Add /skills listing page with free/premium sections
- Add individual skill detail pages with purchase/download CTAs
- Create sample skills: Search Term Audit (free) and PMax Diagnostic (premium)
- Update homepage with featured skills section and email signup
- Add Skills link to site navigation

This establishes the foundation for monetizing MCP skills through Channel 47.